### PR TITLE
Enh 2 6, added -h documentation, added -report flag to specify only one report

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ GITHUB_AUTH_TOKEN=xxx go run main.go
 
 ### Flags
 
-- Short report: `-short` This reduces the report to `New/Not Yet Started` and `In Flight` issues.
-- Print without emojis: `-emoji-off`
-- Specific Release version: `-v XXX` where the XXX can be like `1.22`, the report statistics get extended for the chosen version. To specify multiple version use `-v "1.22, 1.21"`
-- Json output `-json`
+- `-h` info about the flags
+- `-short` shortens the report output (This reduces the report to `New/Not Yet Started` and `In Flight` issues on github.)
+- `-emoji-off` report does not print emojis (see example output with emojis)
+- `-v XXX` specify a k8s release version that should be added to the testgrid report. Where the XXX can be like `1.22`, the report statistics get extended for the chosen version. To specify multiple version use `-v "1.22, 1.21"`
+- `-json` prints in json format
 
 Example
 

--- a/cmd/ci-reporter.go
+++ b/cmd/ci-reporter.go
@@ -24,7 +24,7 @@ import (
 
 func main() {
 	meta := ci_reporter.SetMeta()
-	cireporters := []ci_reporter.CIReport{&ci_reporter.GithubReport{}, &ci_reporter.TestgridReport{}}
+	cireporters := meta.GetReporters()
 
 	// request report data
 	report := ci_reporter.Report{}

--- a/pkg/ci-reporter/github-reporter.go
+++ b/pkg/ci-reporter/github-reporter.go
@@ -70,7 +70,7 @@ func (r *GithubReport) RequestData(meta Meta, wg *sync.WaitGroup) ReportData {
 	}
 
 	// DataPostProcessing collects data requested via assembleGithubRequests/2 and returns ReportData
-	return meta.DataPostProcessing(r, "github", assembleGithubRequests(meta, githubIssueCardConfigs), wg)
+	return meta.DataPostProcessing(r, githubReport, assembleGithubRequests(meta, githubIssueCardConfigs), wg)
 }
 
 // Print extends GithubReport and prints report data to the console

--- a/pkg/ci-reporter/testgrid-reporter.go
+++ b/pkg/ci-reporter/testgrid-reporter.go
@@ -46,7 +46,7 @@ func (r *TestgridReport) RequestData(meta Meta, wg *sync.WaitGroup) ReportData {
 		}
 	}
 
-	return meta.DataPostProcessing(r, "testgrid", assembleTestgridRequests(meta, requiredJobs), wg)
+	return meta.DataPostProcessing(r, testgridReport, assembleTestgridRequests(meta, requiredJobs), wg)
 }
 
 // Print extends TestgridReport and prints report data to the console

--- a/pkg/ci-reporter/vars.go
+++ b/pkg/ci-reporter/vars.go
@@ -23,6 +23,12 @@ import (
 	"sync"
 )
 
+// Reports
+const (
+	githubReport   = "github"
+	testgridReport = "testgrid"
+)
+
 // Github card ids
 const (
 	newCardsID                   = 4212817


### PR DESCRIPTION
see: https://github.com/encodeflush/ci-signal-report-tasks/issues/6
see: https://github.com/encodeflush/ci-signal-report-tasks/issues/2